### PR TITLE
Add custom item functionality

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -24,9 +24,7 @@ const validateImageUrl = (url: string): Promise<string> => {
   return new Promise((resolve, reject) => {
     const img = new Image();
     img.onload = () => resolve(url);
-    img.onerror = e => {
-      reject(e);
-    };
+    img.onerror = e => reject(e);
     img.src = url;
   });
 };
@@ -244,10 +242,9 @@ export const actions = (search: Search): Actions => ({
     validateFile: file => async (state, actions) => {
       try {
         const url = await validateImageFile(file);
-        actions.updateState({ imageUrl: url, error: null });
+        actions.updateState({ imageUrl: url, isError: false });
       } catch (err) {
-        actions.updateState({ error: "Error loading image" }); // TODO
-        console.error("Failed to load image");
+        actions.updateState({ isError: true });
       }
     },
     validateInput: callback => async (state, actions) => {
@@ -257,7 +254,7 @@ export const actions = (search: Search): Actions => ({
           imageUrl: "",
           title: "",
           file: null,
-          error: null
+          isError: false
         });
         callback({
           id: "custom-" + url,
@@ -266,7 +263,7 @@ export const actions = (search: Search): Actions => ({
           overriddenTitle: null
         });
       } catch (err) {
-        actions.updateState({ error: "Error loading image" }); // TODO
+        actions.updateState({ isError: true });
       }
     }
   },

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -215,11 +215,19 @@ export const actions = (search: Search): Actions => ({
       actions.persistState();
     },
     remove: (id: MediaId) => (state, actions) => {
-      actions.updateState({ items: state.items.filter(item => item.id != id) });
+      const newItems = state.items.filter(item => {
+        const shouldKeep = item.id != id;
+        if (!shouldKeep) {
+          URL.revokeObjectURL(item.image);
+        }
+        return shouldKeep;
+      });
+      actions.updateState({ items: newItems });
       actions.persistState();
     },
     removeAll: () => (state, actions) => {
       if (confirm("Remove all items?")) {
+        state.items.forEach(item => URL.revokeObjectURL(item.image));
         actions.updateState({ items: [] });
       } else {
         actions.updateState({});

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -237,6 +237,9 @@ export const actions = (search: Search): Actions => ({
   },
   custom: {
     updateState: newState => {
+      if (newState.imageUrl === "") {
+        newState.isError = false;
+      }
       return newState;
     },
     validateFile: file => async (state, actions) => {

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -41,6 +41,12 @@ const validateImageFile = async (file: File): Promise<string> => {
   }
 };
 
+const randomId = (): string => {
+  return Math.random()
+    .toString()
+    .substr(2);
+};
+
 export interface Actions {
   getState: () => (state: State) => ActionResult<State>;
   search: Actions.Search;
@@ -253,14 +259,16 @@ export const actions = (search: Search): Actions => ({
     validateInput: callback => async (state, actions) => {
       try {
         const url = await validateImageUrl(state.imageUrl);
+
         actions.updateState({
           imageUrl: "",
           title: "",
           file: null,
           isError: false
         });
+
         callback({
-          id: "custom-" + url,
+          id: "custom:" + randomId(),
           title: state.title,
           image: url,
           overriddenTitle: null

--- a/src/search.ts
+++ b/src/search.ts
@@ -43,9 +43,8 @@ export class AniListSearch implements Search {
 
     const json = await result.json();
 
-    // TODO: Catch
     return json.data.page.media.map(media => ({
-      id: mediaType + media.id,
+      id: mediaType + ":" + media.id,
       title: media.title.romaji,
       image: media.coverImage.large
     }));

--- a/src/state.ts
+++ b/src/state.ts
@@ -3,6 +3,7 @@ import { Media, MediaId, MediaType } from "./models";
 export interface State {
   search: State.Search;
   selections: State.Selections;
+  custom: State.Custom;
   bingo: State.Bingo;
 }
 
@@ -18,6 +19,13 @@ export namespace State {
 
   export interface Selections {
     items: Media[];
+  }
+
+  export interface Custom {
+    title: string;
+    imageUrl: string;
+    file: File;
+    error: string;
   }
 
   export interface Bingo {
@@ -72,6 +80,12 @@ export const initialState: State = {
   },
   selections: {
     items: []
+  },
+  custom: {
+    title: "",
+    imageUrl: null,
+    file: null,
+    error: null
   },
   bingo: State.Bingo.initial
 };

--- a/src/state.ts
+++ b/src/state.ts
@@ -25,7 +25,7 @@ export namespace State {
     title: string;
     imageUrl: string;
     file: File;
-    error: string;
+    isError: boolean; // Can't really tell what the reason was
   }
 
   export interface Bingo {
@@ -85,7 +85,7 @@ export const initialState: State = {
     title: "",
     imageUrl: null,
     file: null,
-    error: null
+    isError: false
   },
   bingo: State.Bingo.initial
 };

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -125,17 +125,28 @@ body {
   flex: 1;
 }
 
+.app-custom,
 .app-bingo_settings {
   margin-top: 10px;
 }
 
-.app-bingo_settings__label {
-  display: block;
+.app-bingo_settings__label,
+.app-custom__label {
+  display: flex;
   padding-bottom: 8px;
 }
 
-.app-bingo_settings__label > span {
+.app-bingo_settings__label > span,
+.app-custom__label > span {
   margin-right: 10px;
+}
+
+.app-custom__input {
+  flex: 1;
+}
+
+.app-custom__explanation {
+  font-size: 0.8em;
 }
 
 .app-bingo {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -41,7 +41,8 @@ body {
   max-width: 100%;
 }
 
-.app-search__error {
+.app-search__error,
+.app-custom__error {
   color: #ff0000;
   padding: 0 0 10px 10px;
 }

--- a/src/views/bingo.tsx
+++ b/src/views/bingo.tsx
@@ -170,7 +170,7 @@ export const bingoSettings: View<State.Bingo, Actions.Bingo> = (
     </label>
 
     <label class="app-bingo_settings__label">
-      <span>Show site URL in footer</span>
+      <span>Show URL in footer</span>
       <input
         type="checkbox"
         checked={state.showCredit}

--- a/src/views/custom.tsx
+++ b/src/views/custom.tsx
@@ -1,0 +1,70 @@
+import { h, View } from "hyperapp";
+import { State } from "../state";
+import { Actions } from "../actions";
+
+const isSecure = window.location.protocol === "https:";
+const errorMessage = (state: State.Custom): string => {
+  if (state.isError) {
+    const maybeInsecure = isSecure && state.imageUrl.startsWith("http:");
+    const extra = maybeInsecure ? " that is available over HTTPS" : "";
+
+    return `Could not load image. Please check that the file/URL is a valid image${extra}.`;
+  } else {
+    return null;
+  }
+};
+
+export const custom: View<State, Actions> = (state, actions) => (
+  <fieldset class="app-custom">
+    <legend>Custom</legend>
+    <form
+      onsubmit={e => {
+        e.preventDefault();
+        actions.custom.validateInput(actions.selections.add);
+      }}
+    >
+      <div class="app-custom__explanation">
+        Add your own items! Note that local files might not persist after a page
+        refresh.
+      </div>
+      <div class="app-custom__error">{errorMessage(state.custom)}</div>
+      <label class="app-custom__label">
+        <span>Title</span>
+        <input
+          class="app-custom__input"
+          type="text"
+          placeholder="Custom title"
+          value={state.custom.title}
+          oninput={e => actions.custom.updateState({ title: e.target.value })}
+        />
+      </label>
+      <label class="app-custom__label">
+        <span>Image URL</span>
+        <input
+          type="text"
+          class="app-custom__input"
+          placeholder="https://example.com/image.png"
+          value={state.custom.imageUrl}
+          oninput={e =>
+            actions.custom.updateState({ imageUrl: e.target.value })
+          }
+        />
+        <button
+          onclick={e => {
+            (document.querySelector(".js-file-input") as HTMLElement).click();
+            e.preventDefault();
+          }}
+        >
+          Select local image
+        </button>
+      </label>
+      <input
+        class="js-file-input"
+        style={{ display: "none" }}
+        type="file"
+        onchange={e => actions.custom.validateFile(e.target.files[0])}
+      />
+      <button type="submit">Submit</button>
+    </form>
+  </fieldset>
+);

--- a/src/views/custom.tsx
+++ b/src/views/custom.tsx
@@ -50,9 +50,10 @@ export const custom: View<State, Actions> = (state, actions) => (
           }
         />
         <button
+          type="button"
           onclick={e => {
-            (document.querySelector(".js-file-input") as HTMLElement).click();
             e.preventDefault();
+            (document.querySelector(".js-file-input") as HTMLElement).click();
           }}
         >
           Select local image

--- a/src/views/main.tsx
+++ b/src/views/main.tsx
@@ -4,6 +4,7 @@ import { Actions } from "../actions";
 import { bingoChart, bingoSettings, maxItems } from "./bingo";
 import { searchForm, searchResults } from "./search";
 import { selections } from "./selections";
+import { custom } from "./custom";
 import { MediaType } from "../models";
 
 export const view: View<State, Actions> = (state, actions) => (
@@ -38,6 +39,8 @@ export const view: View<State, Actions> = (state, actions) => (
       </fieldset>
 
       {selections(state.selections, actions.selections)}
+
+      {custom(state, actions)}
 
       {bingoSettings(state.bingo, actions.bingo)}
 


### PR DESCRIPTION
Allow users to define their own items, in case they can't find the item
in search, or if they're making a bingo that isn't anime/manga. Accepts
image URLs or local images (which are converted to object URLs).